### PR TITLE
fix(release): add prepack script to build before publishing

### DIFF
--- a/packages/code-assist/package.json
+++ b/packages/code-assist/package.json
@@ -14,8 +14,9 @@
     "compile": "tsc index.ts && shx chmod +x dist/*.js",
     "start": "node dist/index.js",
     "build": "bun clean && bun build index.ts --outdir dist --target=node",
-    "prepack": "npm run build",
-    "build:dist": "bun clean && bun build index.ts --outdir dist --target=node --format=cjs --minify && echo '{\"type\": \"commonjs\"}' > dist/package.json && cp README.md CHANGELOG.md dist && zip -r dist_$(date +%Y%m%d).zip dist",
+    "build:prepare": "bun clean && bun build index.ts --outdir dist --target=node --format=cjs --minify && echo '{\"type\": \"commonjs\"}' > dist/package.json && cp README.md CHANGELOG.md dist",
+    "build:dist": "npm run build:prepare && zip -r dist_$(date +%Y%m%d).zip dist",
+    "prepack": "npm run build:prepare",
     "test": "bun test tests/unit.test.ts",
     "test:integration": "bun test tests/integration.test.ts"
   },

--- a/packages/code-assist/package.json
+++ b/packages/code-assist/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@googlemaps/code-assist-mcp",
   "version": "0.1.0",
-  "main": "code-assist/index.js",
+  "main": "dist/index.js",
   "type": "module",
   "bin": {
     "google-maps-platform-code-assist": "dist/index.js"
@@ -14,6 +14,7 @@
     "compile": "tsc index.ts && shx chmod +x dist/*.js",
     "start": "node dist/index.js",
     "build": "bun clean && bun build index.ts --outdir dist --target=node",
+    "prepack": "npm run build",
     "build:dist": "bun clean && bun build index.ts --outdir dist --target=node --format=cjs --minify && echo '{\"type\": \"commonjs\"}' > dist/package.json && cp README.md CHANGELOG.md dist && zip -r dist_$(date +%Y%m%d).zip dist",
     "test": "bun test tests/unit.test.ts",
     "test:integration": "bun test tests/integration.test.ts"


### PR DESCRIPTION
Update package.json in `code-assist` to

0. Add a `build:prepare` script that builds the distributable release without any local zipfile
1. Add a `prepack` command so that `npm run publish` github action will always run the `build:prepare` script before uploading a release to NPM
2. Select the correct `main` relative directory entry point to the code-assist server in the `/dist` folder

cc/ @wangela  @caio1985 