### PR TITLE
Feat: Allow users to specify which port to start the MCP server and avoid port collisions.

### DIFF
--- a/packages/code-assist/README.md
+++ b/packages/code-assist/README.md
@@ -28,7 +28,7 @@ When used with an AI agent for coding assistance, this MCP server helps ground i
 For any MCP client that supports installation via npm, use the command line to install the [@googlemaps/code-assist-mcp](https://www.npmjs.com/package/@googlemaps/code-assist-mcp) MCP server to your local machine:
 
 ```
-npx -y @googlemaps/code-assist-mcp
+npx -y @googlemaps/code-assist-mcp [--port 3000]
 ```
 
 ### **Install via JSON configuration (all other MCP clients)**
@@ -40,7 +40,7 @@ Most MCP clients have a JSON file for their MCP configuration such as **mcp.json
   "mcpServers": {
     "google-maps-platform-code-assist": {
       "command": "npx",
-      "args": ["-y", "@googlemaps/code-assist-mcp"]
+      "args": ["-y", "@googlemaps/code-assist-mcp", "--port", "3000"]
     }
   }
 }

--- a/packages/code-assist/index.ts
+++ b/packages/code-assist/index.ts
@@ -316,14 +316,22 @@ async function runServer() {
         }));
     });
 
-    const PORT = 3000;
-    app.listen(PORT, (error: any) => {
-        if (error) {
-            console.error('Failed to start HTTP server:', error);
-            process.exit(1);
-        }
-        console.info(`Google Maps Platform Code Assist Server listening on port ${PORT} for HTTP`);
-    });
+    const startHttpServer = (port: number) => {
+        const server = app.listen(port, () => {
+            console.info(`Starting Google Maps Platform Code Assist Server listening on port ${port} for HTTP`);
+        })
+        .on('error', (error: any) => {
+            if (error.code === 'EADDRINUSE') {
+                console.log(`Port ${port} is in use, trying port ${port + 1}...`);
+                startHttpServer(port + 1);
+            } else {
+                console.error('Failed to start HTTP server:', error);
+                process.exit(1);
+            }
+        });
+    };
+
+    startHttpServer(3000);
 }
 
 if (process.env.NODE_ENV !== 'test') {

--- a/packages/code-assist/index.ts
+++ b/packages/code-assist/index.ts
@@ -316,14 +316,24 @@ async function runServer() {
         }));
     });
 
-    const startHttpServer = (port: number) => {
-        const server = app.listen(port, () => {
-            console.info(`Starting Google Maps Platform Code Assist Server listening on port ${port} for HTTP`);
+    const portIndex = process.argv.indexOf('--port');
+    let port = 3000;
+
+    if (portIndex > -1 && process.argv.length > portIndex + 1) {
+        const parsedPort = parseInt(process.argv[portIndex + 1], 10);
+        if (!isNaN(parsedPort)) {
+            port = parsedPort;
+        }
+    }
+
+    const startHttpServer = (p: number) => {
+        const server = app.listen(p, () => {
+            console.info(`Google Maps Platform Code Assist Server listening on port ${p} for HTTP`);
         })
         .on('error', (error: any) => {
             if (error.code === 'EADDRINUSE') {
-                console.log(`Port ${port} is in use, trying port ${port + 1}...`);
-                startHttpServer(port + 1);
+                console.log(`Port ${p} is in use, trying port ${p + 1}...`);
+                startHttpServer(p + 1);
             } else {
                 console.error('Failed to start HTTP server:', error);
                 process.exit(1);
@@ -331,7 +341,7 @@ async function runServer() {
         });
     };
 
-    startHttpServer(3000);
+    startHttpServer(port);
 }
 
 if (process.env.NODE_ENV !== 'test') {


### PR DESCRIPTION
Users can now specify which port to start the MCP server. If the port is in use, it will start on a port closest to that one by doing increments of 1.

Fixes #13 
