### PR TITLE
fix: update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,17 +34,31 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node for Publishing
+      # 1. Setup Node using the default registry (npmjs.org)
+      - name: Setup Node (Default Registry)
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: 'https://wombat-dressing-room.appspot.com/'
 
+      # Setup Bun (required by the package's build/prepack scripts)
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+
+      # 2. Install Dependencies from the default registry
       - name: Install Dependencies
         run: npm install --workspace=packages/code-assist
 
+      # 3. Setup Node again, configuring the WDR registry for publishing
+      - name: Setup Node for Publishing (WDR Registry)
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: "https://wombat-dressing-room.appspot.com/"
+
+      # 4. Publish to WDR
       - name: Publish
         # npm publish will trigger the build via the prepack hook
         run: npm publish --workspace=packages/code-assist
         env:
+          # The NODE_AUTH_TOKEN is used to authenticate against the Wombat Dressing Room registry.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_WOMBOT_TOKEN }}

--- a/packages/code-assist/package.json
+++ b/packages/code-assist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@googlemaps/code-assist-mcp",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "dist/index.js",
   "type": "module",
   "bin": {
@@ -14,7 +14,7 @@
     "compile": "tsc index.ts && shx chmod +x dist/*.js",
     "start": "node dist/index.js",
     "build": "bun clean && bun build index.ts --outdir dist --target=node",
-    "build:prepare": "bun clean && bun build index.ts --outdir dist --target=node --format=cjs --minify && { echo '#!/usr/bin/env node'; cat dist/index.js; } > dist/index.js.tmp && mv dist/index.js.tmp dist/index.js && echo '{\"type\": \"commonjs\"}' > dist/package.json && cp README.md dist",
+    "build:prepare": "bun clean && bun build index.ts --outdir dist --target=node --format=cjs --minify && { echo '#!/usr/bin/env node'; cat dist/index.js; } > dist/index.js.tmp && mv dist/index.js.tmp dist/index.js && shx chmod +x dist/index.js && echo '{\"type\": \"commonjs\"}' > dist/package.json && cp README.md dist",
     "build:dist": "npm run build:prepare && zip -r dist_$(date +%Y%m%d).zip dist",
     "prepack": "npm run build:prepare",
     "test": "bun test tests/unit.test.ts",
@@ -29,6 +29,8 @@
     "@modelcontextprotocol/sdk": "^1.11.3",
     "@types/node": "^22.15.18",
     "axios": "1.9.0",
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
     "google-auth-library": "^9.15.1",
     "shx": "^0.4.0",
     "typescript": "^5.8.3"

--- a/packages/code-assist/package.json
+++ b/packages/code-assist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@googlemaps/code-assist-mcp",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "dist/index.js",
   "type": "module",
   "bin": {
@@ -24,6 +24,11 @@
   "author": "",
   "license": "ISC",
   "description": "",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/googlemaps/platform-ai.git",
+    "directory": "packages/code-assist"
+  },
   "dependencies": {
     "@google-cloud/vertexai": "^1.10.0",
     "@modelcontextprotocol/sdk": "^1.11.3",

--- a/packages/code-assist/package.json
+++ b/packages/code-assist/package.json
@@ -23,12 +23,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "description": "",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/googlemaps/platform-ai.git",
-    "directory": "packages/code-assist"
-  },
+  "description": "Google Maps Platform Code Assist MCP (Model Context Protocol) service",
   "dependencies": {
     "@google-cloud/vertexai": "^1.10.0",
     "@modelcontextprotocol/sdk": "^1.11.3",


### PR DESCRIPTION
Fix github release workflow

1. Ensure dependencies are installed from the public registry before configuring the environment for publishing via WDR. 
2. Setup Bun prior to install 
