### PR TITLE
feat: added mcp registry values

### DIFF
--- a/packages/code-assist/package.json
+++ b/packages/code-assist/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@googlemaps/code-assist-mcp",
+  "mcpName": "io.github.googlemaps/code-assist-mcp",
   "version": "0.1.7",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/code-assist/server.json
+++ b/packages/code-assist/server.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.googlemaps/code-assist-mcp",
+  "description": "Google Maps Platform Code Assist MCP (Model Context Protocol) service",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/googlemaps/platform-ai",
+    "source": "github"
+  },
+  "version": "1.0.0",
+  "packages": [
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "@googlemaps/code-assist-mcp",
+      "version": "1.0.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
For the server to be published to the mcp registry I added the needed values. Now after this gets added the command to add the mcp server to registry has to be run.

It's documented here: https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/publish-server.md


This is the registry and how it currently looks like.
https://registry.modelcontextprotocol.io/v0/servers

For now I assumed version 1.0.0 will come soon and I named it io.github.googlemaps/code-assist-mcp but this could be changed to io.github.googlemaps/platform-ai if that is preferred.

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary) Unsure if I should docs for this somewhere.

For #39  🦕
