### PR TITLE
Feat - add Code Assist to Anthropic MCP Marketplace registry

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,132 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Workflow to publish MCP server to the official MCP Registry
+name: Publish MCP Server
+
+on:
+  workflow_call:
+    inputs:
+      package_published:
+        description: 'Whether the NPM package was successfully published'
+        required: true
+        type: boolean
+  workflow_dispatch: # manual trigger for testing
+
+concurrency:
+  group: mcp-publishing
+  cancel-in-progress: true
+
+jobs:
+  publish-mcp:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.package_published }}
+    permissions:
+      id-token: write  # Required for GitHub OIDC authentication
+      contents: read
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      
+      - name: Setup Go (for MCP Publisher)
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      
+      - name: Install and Build MCP Publisher
+        run: |
+          git clone --depth 1 https://github.com/modelcontextprotocol/registry mcp-registry
+          cd mcp-registry
+          make publisher
+          cp cmd/publisher/bin/mcp-publisher ../mcp-publisher
+          cd ..
+          chmod +x mcp-publisher
+          rm -rf mcp-registry
+      
+      - name: Validate server.json
+        working-directory: packages/code-assist
+        run: |
+          # Basic validation that server.json exists and has required fields
+          if [ ! -f "server.json" ]; then
+            echo "❌ server.json not found"
+            exit 1
+          fi
+          
+          # Check for required fields using jq
+          if ! command -v jq &> /dev/null; then
+            sudo apt-get update && sudo apt-get install -y jq
+          fi
+          
+          name=$(jq -r '.name // empty' server.json)
+          if [ -z "$name" ]; then
+            echo "❌ server.json missing 'name' field"
+            exit 1
+          fi
+          
+          echo "✅ server.json validation passed"
+          echo "📦 Publishing MCP server: $name"
+      
+      - name: Login to MCP Registry (GitHub OIDC)
+        working-directory: packages/code-assist
+        run: |
+          echo "🔐 Authenticating with MCP Registry using GitHub OIDC..."
+          ../mcp-publisher login github-oidc
+      
+      - name: Publish to MCP Registry
+        working-directory: packages/code-assist
+        run: |
+          echo "🚀 Publishing to MCP Registry..."
+          ../mcp-publisher publish
+      
+      - name: Verify Publication
+        working-directory: packages/code-assist
+        run: |
+          # Extract server name from server.json for verification
+          server_name=$(jq -r '.name' server.json)
+          registry_url="https://registry.modelcontextprotocol.io/servers/${server_name}"
+          
+          echo "📡 Verifying publication at: $registry_url"
+          
+          # Wait a moment for registry to update
+          sleep 10
+          
+          # Check if server appears in registry
+          if curl -f -s "$registry_url" > /dev/null; then
+            echo "✅ MCP server successfully published and verified!"
+            echo "🌐 Available at: $registry_url"
+          else
+            echo "⚠️  Publication completed but verification failed. This may be due to registry propagation delays."
+            echo "🔍 Manual verification recommended at: $registry_url"
+          fi
+      
+      - name: Notify on Success
+        if: success()
+        run: |
+          server_name=$(jq -r '.name' packages/code-assist/server.json)
+          echo "✅ MCP Server '$server_name' published successfully to the MCP Registry!"
+      
+      - name: Notify on Failure
+        if: failure()
+        run: |
+          echo "❌ MCP Server publishing failed. Check the logs above for details."
+          echo "💡 Common issues:"
+          echo "   - Package not yet available on NPM (try again in a few minutes)"
+          echo "   - server.json validation errors"
+          echo "   - Authentication issues"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,3 +62,12 @@ jobs:
         env:
           # The NODE_AUTH_TOKEN is used to authenticate against the Wombat Dressing Room registry.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_WOMBOT_TOKEN }}
+
+  # Publish to MCP Registry after successful NPM publishing
+  publish-mcp:
+    needs: publish
+    if: ${{ needs.publish.result == 'success' }}
+    uses: ./.github/workflows/publish-mcp.yml
+    with:
+      package_published: true
+    secrets: inherit

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "packages/code-assist": "0.1.7"
+  "packages/code-assist": "0.2.0"
 }

--- a/packages/code-assist/.gitignore
+++ b/packages/code-assist/.gitignore
@@ -35,3 +35,6 @@ coverage/
 *.tmp
 .temp/
 tmp/
+
+# MCP Registry local authentication tokens
+.mcpregistry_*

--- a/packages/code-assist/README.md
+++ b/packages/code-assist/README.md
@@ -444,6 +444,43 @@ This server implementation includes a standard `/health` endpoint. This is a bes
 
 -----
 
+<!-- [START maps_Developer] -->
+
+## 🛠️ Developer: Manual Release Process
+
+> **Note:** Normally releases are automated via GitHub Actions, but due to a current workflow bug, manual releases are required. Follow these steps:
+
+**Manual Release Steps:**
+
+**1. Bump Version Numbers**
+Update version in all required files:
+- `packages/code-assist/package.json`
+- `packages/code-assist/server.json`
+- `.release-please-manifest.json` (project root)
+
+**2. Create Changelog Entry**
+Update `packages/code-assist/CHANGELOG.md` with new version details.
+
+**3. Build and Publish to NPM**
+```bash
+cd packages/code-assist
+npm run build:prepare
+npm login
+npm publish
+```
+
+**4. Publish to MCP Registry**
+```bash
+npx @modelcontextprotocol/mcp-publisher login github
+npx @modelcontextprotocol/mcp-publisher publish
+```
+
+The MCP Registry validates that the NPM package is live and the `mcpName` field in `package.json` matches the server name before allowing publication.
+
+<!-- [END maps_Developer] -->
+
+-----
+
 <!-- [START maps_Terms] -->
 
 ## **Terms of Service**

--- a/packages/code-assist/package.json
+++ b/packages/code-assist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@googlemaps/code-assist-mcp",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "mcpName": "io.github.ryanbaumann/platform-ai",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/code-assist/package.json
+++ b/packages/code-assist/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@googlemaps/code-assist-mcp",
   "version": "0.1.7",
+  "mcpName": "io.github.ryanbaumann/platform-ai",
   "main": "dist/index.js",
   "type": "module",
   "bin": {

--- a/packages/code-assist/server.json
+++ b/packages/code-assist/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/googlemaps/platform-ai",
     "source": "github"
   },
-  "version": "0.1.7",
+  "version": "0.2.0",
   "packages": [
     {
       "registry_type": "npm",
       "identifier": "@googlemaps/code-assist-mcp",
-      "version": "0.1.7",
+      "version": "0.2.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/code-assist/server.json
+++ b/packages/code-assist/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.ryanbaumann/platform-ai",
+  "description": "Google Maps Platform Code Assist MCP",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/googlemaps/platform-ai",
+    "source": "github"
+  },
+  "version": "0.1.7",
+  "packages": [
+    {
+      "registry_type": "npm",
+      "identifier": "@googlemaps/code-assist-mcp",
+      "version": "0.1.7",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Publish Code Assist MCP to https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/publish-server.md

Currently blocked on publishing by: https://github.com/modelcontextprotocol/registry/issues/400

Manually bumped NPM to version 0.2.0 (in this PR) because we needed to add a new required piece of metadata 

This PR introduces the necessary configuration and documentation to support publishing the `code-assist` MCP server. It includes a version bump to `0.2.0`, adds the required `server.json` manifest, and updates the CI/CD pipeline for automated publishing.

### Key Changes:

*   **MCP Server Manifest (`server.json`)**:
    *   Adds the `packages/code-assist/server.json` file, which is required to register the server with the MCP Registry.

*   **CI/CD Pipeline (`.github/workflows/`)**:
    *   Adds a new workflow, `.github/workflows/publish-mcp.yml`, to automatically publish the server to the MCP Registry upon new version tags.
    *   Updates the existing `.github/workflows/publish.yml` to integrate with the new MCP publishing steps.

*   **Versioning (`package.json`, `.release-please-manifest.json`)**:
    *   Bumps the version of `packages/code-assist` from `0.1.7` to `0.2.0`.
    *   Updates the `release-please` manifest to reflect the new version.

*   **Security (`.gitignore`)**:
    *   Adds `.mcpregistry_*` to the `.gitignore` in `packages/code-assist` to prevent local authentication tokens from being committed.

*   **Documentation (`README.md`)**:
    *   Updates `packages/code-assist/README.md` to include instructions for the manual release process, which is a temporary workaround for a bug in the GitHub Actions workflow.