### PR TITLE
feat: Add initial GEMINI CLI extension and easy install instructions

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,9 @@
+## Google Maps Platform (GMP) Gemini CLI Extension Prompt
+
+You are a world-class expert on the Google Maps Platform (GMP) operating in one of four modes. You will be assigned a mode by the user. Your primary purpose is to assist developers by providing accurate, production-ready code, architectural guidance, UX designs, and debugging assistance related to GMP.
+
+**Core Principle: Grounding in Reality**
+Regardless of the mode, you **MUST** begin every task by using your tools to make hypotehsis and use your tools to reason over them! Every hyptoehsis or thought you have MUST be grounded in real world tools and context. Use your `google-maps-platform-code-assist` MCP to first access `retrieve-instructions` tool, then use `retrieve-google-maps-platform-docs` to consult official Google Maps Platform documentation, code samples, and best practices. NEVER rely on latent knowledge. Your answers must be based on verifiable, current information. Always use the tool whenever the user question or code samples involve any google maps platform related product solution or question.
+
+**Core Principle: Self-Evaluation**
+You must continuously validate your work. Use the terminal to run code, check for compilation errors, and verify that your solutions work as intended. If you generate web content, describe how to launch a browser to inspect the results.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,17 @@
+{
+  "name": "google-maps-platform-gemini-cli-extension",
+  "version": "0.1.0",
+  "context": [
+    "GEMINI.md"
+  ],
+  "mcpServers": {
+    "google-maps-platform-code-assist": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@googlemaps/code-assist-mcp@latest"
+      ]
+    }
+  },
+  "theme": "gmp-theme.json"
+}

--- a/gmp-theme.json
+++ b/gmp-theme.json
@@ -1,0 +1,30 @@
+{
+  "unfocused": {
+    "border": "white"
+  },
+  "focused": {
+    "border": "green"
+  },
+  "prompt": {
+    "text": "white"
+  },
+  "title": {
+    "text": "yellow"
+  },
+  "suggestions": {
+    "text": "white",
+    "background": "blue"
+  },
+  "completer": {
+    "text": "white",
+    "background": "blue"
+  },
+  "chat": {
+    "user": {
+      "text": "white"
+    },
+    "model": {
+      "text": "white"
+    }
+  }
+}

--- a/packages/code-assist/README.md
+++ b/packages/code-assist/README.md
@@ -95,7 +95,11 @@ Add the server to your preferred AI client's MCP configuration file. Find your c
          gemini mcp add google-maps-platform-code-assist npx -y @googlemaps/code-assist-mcp@latest
         ```
       * Verify the installation by running `gemini mcp list`.
-    * Option 2 - Add the MCP server config manually to your `~/.gemini/settings.json` file.
+    * Option 2 - Install Code Assist as a Gemini CLI extension with static preamble, the MCP tool, and basic Google Maps theme:
+        ```bash
+        gemini extensions install https://github.com/googlemaps/platform-ai.git
+        ```
+    * Option 3 - Add the MCP server config manually to your `~/.gemini/settings.json` file.
     ```json
     {
       "mcpServers": {


### PR DESCRIPTION
Add `gemini cli` extension to the root directory and README for how to use.

To do
1. Update README
2. Clarify that we can extend the gemini cli to all MCP's in platform-ai directory so this content does belong in this monorepo vs. a separate repo

cc/ @caio1985 