### PR TITLE
Fix package name typos in Claude Code installation instructions

### DIFF
--- a/packages/code-assist/README.md
+++ b/packages/code-assist/README.md
@@ -110,7 +110,7 @@ Add the server to your preferred AI client's MCP configuration file. Find your c
 2. **[Claude Code](https://docs.anthropic.com/en/docs/claude-code/mcp)**
     * Option 1 - Add the server directly from your command line (assuming you have Claude Code already installed):
         ```bash
-            claude mcp add google-maps-platform-code-assist -- npx -y @googlemaps/code-assist@latest
+            claude mcp add google-maps-platform-code-assist -- npx -y @googlemaps/code-assist-mcp@latest
         ```
         * Verify the installation by running `claude mcp list`.
         * **Windows Users:** On native Windows (not WSL), you must use the `cmd /c` wrapper for `npx` commands to work correctly.
@@ -123,7 +123,7 @@ Add the server to your preferred AI client's MCP configuration file. Find your c
         "google-maps-platform-code-assist": {
           "command": "npx",
           "args": [
-            "-y", "@googlemaps/code-assist-mc@latest"
+            "-y", "@googlemaps/code-assist-mcp@latest"
           ]
         }
       }


### PR DESCRIPTION
- Corrected @googlemaps/code-assist@latest to @googlemaps/code-assist-mcp@latest
- Fixed @googlemaps/code-assist-mc@latest to @googlemaps/code-assist-mcp@latest

These typos would prevent users from successfully installing the MCP server through Claude Code. The correct package name is @googlemaps/code-assist-mcp.

🤖 Generated with [Claude Code](https://claude.ai/code)

Thank you for opening a Pull Request!

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
