### PR TITLE
chore: rename extension and update context file name

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,9 +1,7 @@
 {
-  "name": "google-maps-platform-gemini-cli-extension",
+  "name": "google-maps-platform",
   "version": "0.1.0",
-  "context": [
-    "GEMINI.md"
-  ],
+  "contextFileName": "GEMINI.md",
   "mcpServers": {
     "google-maps-platform-code-assist": {
       "command": "npx",


### PR DESCRIPTION
Gemini CLI team member here 👋 

Gemini CLI extensions should not include `gemini-cli-extension` in the name of the extension.
It is redundant since your are installing it using the `gemini extensions install` command and
secondly users need to type out the name to uninstall the extension. So shorter the better 😄 

Changing name of this extension to just `google-maps-platform` makes the most sense.

Also `context` is not a valid field, it is `contextFileName` which I have updated it to. 👍 