### PR TITLE
Add "description" field for Gemini CLI extension marketplace

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,7 @@
 {
   "name": "google-maps-platform",
   "version": "0.1.0",
+  "description": "Ground agents on fresh, official Google Maps Platform documentation and code samples for optimal geo-related developer guidance and code",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "google-maps-platform-code-assist": {


### PR DESCRIPTION
Add "description" field for Gemini CLI extension marketplace that will propagate to the Gemini CLI Marketplace - https://geminicli.com/extensions/browse/
<img width="383" height="259" alt="image" src="https://github.com/user-attachments/assets/eb3e1349-52bc-4483-9d0d-461e9f077709" />
