### PR TITLE
build: fix publish flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,10 @@ concurrency:
   group: publishing
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build-and-test:
     uses: ./.github/workflows/ci.yml

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,6 +29,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 name: Release Please
 


### PR DESCRIPTION
This PR adds the required id-token: write permission at the appropriate level, allowing the publishing workflow to run successfully.

There are currently no proper ways to run the GitHub actions locally before testing them, [like act](https://github.com/nektos/act), which works half of the time, so it is a bit of a painful process. This can be verified by an admin by triggering the Release Please workflow or manually triggering the Publish workflow on a branch and checking if it fails with the same permission error.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #59  🦕
